### PR TITLE
Redefinition of BoostDM region dataset

### DIFF
--- a/build/datasets/boostdm/get_all_regions.py
+++ b/build/datasets/boostdm/get_all_regions.py
@@ -8,8 +8,8 @@ HEADER = ["GENE_ID", "SYMBOL", "PROTEIN_ID", "CHROMOSOME", "START", "END", "CDS_
           "STRAND", "TRANSCRIPT_ID", "START_EXON", "END_EXON"]
 
 
-def get_exons_from_biomart(bm):
-    """ Extract the exon regions from the canonical biomart dataset
+def get_cds_from_biomart(bm):
+    """ Extract the cds regions from the canonical biomart dataset
     
     :param bm: str, path to biomart dataset
     """
@@ -17,46 +17,46 @@ def get_exons_from_biomart(bm):
     biomart_df =  pd.read_csv(bm, sep="\t", names=HEADER)
     biomart_df["STRAND"].replace({-1: "-", 1:"+"}, inplace=True)
 
-    return biomart_df[["CHROMOSOME", "START_EXON", "END_EXON", "STRAND", "GENE_ID", "SYMBOL", "TRANSCRIPT_ID"]]
+    return biomart_df[["CHROMOSOME", "START", "END", "STRAND", "GENE_ID", "SYMBOL", "TRANSCRIPT_ID"]]
 
-def extract_splice_sites(group, num_bases=25):
-    """Extract the splice sites of a gene by retaining 25bp in the intronic regions between exons.
+def extract_splice_sites(group, num_bases=5):
+    """Extract the splice sites of a gene by retaining 5bp in the intronic regions between cds.
     
     :param group: pandas.Dataframe
     :param num_bases: int, number of bases of each splice site
     """
-    group.sort_values(by=['START_EXON', 'END_EXON'], inplace=True)
+    group.sort_values(by=['START', 'END'], inplace=True)
     group.drop_duplicates(inplace=True)
-    group['SP_START_5'] = group['START_EXON'] - np.insert(np.repeat(num_bases, len(group) - 1), 0, 0)
-    group['SP_END_5'] = group['START_EXON'] - np.insert(np.repeat(1, len(group) - 1), 0, 0)
-    group['SP_START_3'] = group['END_EXON'] + np.append(np.repeat(1, len(group) - 1), 0)
-    group['SP_END_3'] = group['END_EXON'] + np.append(np.repeat(num_bases, len(group) - 1), 0)
+    group['SP_START_5'] = group['START'] - np.insert(np.repeat(num_bases, len(group) - 1), 0, 0)
+    group['SP_END_5'] = group['START'] - np.insert(np.repeat(1, len(group) - 1), 0, 0)
+    group['SP_START_3'] = group['END'] + np.append(np.repeat(1, len(group) - 1), 0)
+    group['SP_END_3'] = group['END'] + np.append(np.repeat(num_bases, len(group) - 1), 0)
 
 
     return group
 
 def main(bm, outf):
-    """Reads the biomart dataset and extract the exons regions. 
+    """Reads the biomart dataset and extract the cds regions. 
     Computes the splice sites. 
-    Writes output --> exons + splice sites regions.
+    Writes output --> cds + splice sites regions.
     
     :param bm: str, path to biomart file
     :param outf: str, path to write output
     """
 
-    exons_df = get_exons_from_biomart(bm)
+    cds_df = get_cds_from_biomart(bm)
     
-    exons_by_transcript = exons_df.groupby('TRANSCRIPT_ID')
+    cds_by_transcript = cds_df.groupby('TRANSCRIPT_ID')
 
-    splice_sites = exons_by_transcript.apply(partial(extract_splice_sites))
-    splice_sites.sort_values(by=['CHROMOSOME', 'START_EXON', 'END_EXON'], inplace=True)
+    splice_sites = cds_by_transcript.apply(partial(extract_splice_sites))
+    splice_sites.sort_values(by=['CHROMOSOME', 'START', 'END'], inplace=True)
 
-    with gzip.open(outf + "/cds-25spli.regions.gz", 'wt') as output:
+    with gzip.open(outf + "/cds-5spli.regions.gz", 'wt') as output:
         output.write('\t'.join(['CHROMOSOME', 'START', 'END', 'STRAND', 'GENE_ID', 'TRANSCRIPT_ID', 'SYMBOL']) + '\n')
         for count, line in splice_sites.iterrows():
             output.write( 
-                f"{line['CHROMOSOME']}\t{line['START_EXON']}\t" + \
-                f"{line['END_EXON']}\t{line['STRAND']}\t{line['GENE_ID']}\t" + \
+                f"{line['CHROMOSOME']}\t{line['START']}\t" + \
+                f"{line['END']}\t{line['STRAND']}\t{line['GENE_ID']}\t" + \
                 f"{line['TRANSCRIPT_ID']}\t{line['SYMBOL']}\n")
             
             ## Adding splice variants when applicable

--- a/core/intogen_core/postprocess/drivers/saturation.py
+++ b/core/intogen_core/postprocess/drivers/saturation.py
@@ -41,7 +41,7 @@ def saturation(vep_path, driver_df, regions_df):
                 start = r["START"]
                 end = r["END"]
                 chr_ = str(r["CHROMOSOME"])
-                for data in get(vep_path, chr_, int(start), int(end)):
+                for data in get(vep_path, chr_, int(start) - 1, int(end)):
                     if ("-" != data[22]) and (data[18] == driver):
                         # then it is the canonical transcript
                         l_cases.append([x for x in data[:25]])   
@@ -70,6 +70,7 @@ def cli(drivers):
 
     for driver, df in saturation(vep_path, drivers_df, regions_df):
         df.to_csv(f'{driver}.vep.gz', index=False, compression='gzip', sep='\t')
+        continue
 
 if __name__ == "__main__":
     cli()   


### PR DESCRIPTION
## BoostDM saturation vep files have three main problems:

1. The tabix is skipping systematically the first position of the cds_25bp.regions.tsv.gz
2. We are introducing entire exons that are formed of non coding.

Tackling the problem:

- [x] We want to fix the tabix check
- [x] We want to define a coding region where we take only CDS regions and add + 5 bp at the beginning and at the end

------------------------------------------------------------------------
### BoostDM dataset --> cds-5spli.regions.gz
The Biomart query we use in IntOGen has genomic coordinates that will replace the exon coordinates we use in BoostDM regions, this will align the region definition between IntOGen and BoostDM.

We then redefined the splicing region to be 5 bp instead of 25. 
commit: https://github.com/bbglab/intogen-plus/commit/dc3c9cc974549cec8970f1dfda6878fd42c7e0a8

### DriverSaturation step
New run of the saturation step was done, tackling the issue of the first position error.

commit: https://github.com/bbglab/intogen-plus/commit/9580b1a437030ce35cb712c5020b8b027b8b93dc